### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Parallax effect for images in table view cells.
 I have found many examples using UICollectionView, but I wanted to use a simple UITableView. That is why I decided to create this project.
 
 
-##How it works
+## How it works
 
 Assuming the images have a height greater than the height of the cells:
 * The top cell will show the first part of its image and will hide the bottom overflow.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
